### PR TITLE
Updated friendly id behavior

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -9,10 +9,11 @@ class Book < ActiveRecord::Base
   mount_uploader :document, DocumentUploader
 
   extend FriendlyId
-  friendly_id :title, :use => :slugged
+  friendly_id :slug_candidates, :use => :slugged
   validates_presence_of :title, :slug
-  def should_generate_new_friendly_id?
-    slug.blank? || title_changed?
+
+  def slug_candidates
+    [:title, [:title, :author]]
   end
 
   def link
@@ -22,7 +23,4 @@ class Book < ActiveRecord::Base
       self.url
     end
   end
-
-
-
 end

--- a/test/models/book_test.rb
+++ b/test/models/book_test.rb
@@ -1,7 +1,16 @@
 require 'test_helper'
 
 class BookTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "a book generates a slug from its title" do
+    book = Book.new(:title => "There and Back Again", :author => "Bilbo Baggins")
+    book.valid?
+    assert { book.slug == "there-and-back-again" }
+  end
+
+  test "a book generates a slug from its title and author if the title is not unique" do
+    Book.new(:title => "There and Back Again", :author => "Bilbo Baggins").save!
+    book = Book.new(:title => "There and Back Again", :author => "Pat Murphy")
+    book.valid?
+    assert { book.slug == "there-and-back-again-pat-murphy" }
+  end
 end


### PR DESCRIPTION
New ids are not generated on the title changing. Doing so would result
in links being broken in the future.

If a slug is already taken, try adding the author's name to make a
unique slug.
